### PR TITLE
Bokjunsoo

### DIFF
--- a/BOKJUNSOO/5주차/숨바꼭질.py
+++ b/BOKJUNSOO/5주차/숨바꼭질.py
@@ -1,0 +1,32 @@
+# 가장 빠른 거리 찾는 문제이므로 BFS
+
+from collections import deque
+a,b = map(int, input().split())
+MAX = 10 ** 5
+graph = [0] * (MAX+1)
+
+queue = deque()
+def bfs(a,b):
+    if a == b:
+        print(0)
+        return
+    queue.append(a)
+    while queue:
+        a = queue.popleft()
+        if a == b:
+            print(graph[a])
+            return
+        
+        # 아직 방문하지 않은 노드이고 (0이 아니고 ) 갈 수 있는 방향이라면
+        if 0<= a+1 <= MAX and not graph[a+1]:
+            queue.append(a + 1)
+            graph[a+1] = graph[a] + 1
+
+        if 0<= a-1 <= MAX and not graph[a-1]:   
+            queue.append(a - 1)
+            graph[a-1] = graph[a] + 1
+
+        if 0<= a*2 <= MAX and not graph[a*2]:
+            queue.append(a*2)
+            graph[a*2] = graph[a] + 1
+bfs(a,b)

--- a/BOKJUNSOO/5주차/알고스팟.py
+++ b/BOKJUNSOO/5주차/알고스팟.py
@@ -1,0 +1,46 @@
+from collections import deque
+
+col, row = map(int, input().split())
+graph = [[0] * col for _ in range(row)]
+
+for _ in range(row):
+    list_ = list(map(int, input().strip()))
+    graph[_] = list_
+
+visted = [[-1] * col for _ in range(row)]
+queue = deque()
+dx = [1,0,0,-1]
+dy = [0,-1,1,0]
+
+def bfs(a,b):
+    queue.append((a,b))
+    visted[0][0] = 0
+
+    while queue:
+        x,y = queue.popleft()
+
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+
+            if nx<0 or ny < 0 or nx >= row or ny >= col:
+                continue
+
+            # 아직 방문을 하지 않은 graph에 대해서
+            if visted[nx][ny] == -1:
+                # 벽이 없는 방이라면
+                if graph[nx][ny] == 0:
+                    # 전까지 깻던 벽의 횟수를 그대로 전달(벽이 없으므로 count 하지 않음)
+                    visted[nx][ny] = visted[x][y]
+                    # 우선적으로 벽이 아닌 그래프를 탐색 (비용이 발생안했으므로 아직 기회가 있다다)
+                    queue.appendleft((nx,ny)) 
+                    continue
+                # 벽이 있는 방인경우
+                if graph[nx][ny] == 1:
+                    # 벽을 깼으므로 +1 을 하고, 전까지 부쉈던 벽의 갯수를 함께 넘겨줌
+                    visted[nx][ny] = visted[x][y] + 1
+                    # 나중에 탐색 (벽을 깨는 것에 비용이 발생했으므로 기회가 더이상 없다)
+                    queue.append((nx,ny))
+bfs(0,0)
+print(visted[row-1][col-1])
+

--- a/BOKJUNSOO/5주차/트리순회.py
+++ b/BOKJUNSOO/5주차/트리순회.py
@@ -1,0 +1,29 @@
+n = int(input())
+tree = {}
+for _ in range(n):
+    root, left, right = input().strip().split()
+    tree[root] = [left,right]
+
+def preorder(root):
+    if root != ".":
+        print(root, end="")
+        preorder(tree[root][0])
+        preorder(tree[root][1])
+
+def inorder(root):
+    if root != ".":
+        inorder(tree[root][0])
+        print(root,end="")
+        inorder(tree[root][1])
+
+def postorder(root):
+    if root != ".":
+        postorder(tree[root][0])
+        postorder(tree[root][1])
+        print(root, end='')
+
+preorder('A')
+print()
+inorder('A')
+print()
+postorder('A')


### PR DESCRIPTION
이번주도 고생하셨습니다. 
풀다보니 모두 BFS 문제였네요 ㅎㅎ.. 다음주는 그래프탐색 문제도 좋지만, 백트랙킹이나 그리디, 브루트포스  중에서 한번 골라보겠습니다

# ⭐ 알고스택
이건 제가 풀 문제라 미리 빡세게 설명을 한번 작성해보고 제가 풀어가는 방향이 이랬다~ 정도를 써보겠습니다.
 
## 브루트 포스인가?
저는 처음에 이 문제의 제한조건이 100 이하인것을 보고
`브루트 포스인가?` 를 먼저 생각했습니다. 

- 각각의 방에 대해서 모든 경우에 경로를 완전탐색하고
- 각 경로에 대해 부순 벽의 갯수를 기록하고 마지막에 최솟값을 구하기

이런 경우에는 다음의 두 가지를 구현해야 했는데 각각의 제약이 존재했습니다. 

- 백트랙킹 하며 부순벽을 다시 세우고 다른 방향으로 탐색:
```
사실 구현할 방법이 생각 안났습니다.
그리고 차라리 이거를 구현하기 보다는 `BFS로 탐색`하는게 났지 않나를 고민했구요.
```

- 깊은 복사로 처음의 그래프를 복구 후 처음부터 다시 탐색:
```
이거는 복구를 하게 된다면 겹치지 않은 경로를 찾을 방법이 없겠다 생각이 들었습니다.

그러면 부순 벽의순서를 기억해야 할 것인데 이 생각을 하고 나니 
100x 100 행렬이라 할지라도
그 시간복잡도가 어마무시할 것으로 
무조건 시간초과가 나겠구나 생각을 했습니다.
```

## 결국 BFS
결국 그래서 BFS가 답이겠구나 생각을 했습니다.
늘 하던 방식으로 방문처리를 해 가면서 ( 미로 최단거리 찾기문제 혹은 간선까지의 최단거리 찾기) N-1, M-1에 도착하면 됐습니다.

근데 벽을 가장 적게 부숴야하므로
- 벽을 부수는 경우
- 벽을 부수지 않는경우
위의 두가지 경우에서 각각 `비용이 발생` vs `비용이 발생하지 않음` 두가지로 나뉘었습니다.

따라서 이를 고려해 러프하게 설명을 해보자면
```
벽을 부순 방에서 다음 탐색을 하는 것은 미루고 (비용이 증가했으니 기회를 박탈)
큐에 있는 다른 방에 대해서 아직 비용이 증가하지 않은 방에게 기회를 주는 방식!
```
이렇게 정리가 되니
다익스트라 알고리즘이 떠올랐습니다.
큐를 사용하긴 하나 각각의 우선순위가 존재하여
- 벽을 부숴서 비용이 증가한 경우 (후순위로 밀림)
- 아직 벽을 부수지 않고 바로 지나갈 수 있는 빈방 (우선순위로 들어옴)

위를 구현하면 풀리겠거니 하여
deque 를 이용하여 
우선순위의 방은 큐 앞쪽에 (appendleft)
후순위로 밀린 방은 큐 뒤에 (append) 넣어주면 되는 문제였습니다.

구현 자체는 쉽다 생각하는데 문제가 좀 재밌던것 같습니다.

---

# ⭐ 숨바꼭질
이 문제는 늘 하던 2차원 탐색의 BFS가 아닌 단순한 일차원리스트 문제로 풀렸습니다.
(실제 문제를 머릿속에 그려보면 일직선 위에 있다고 생각했습니다.)

3가지 경우에 대해서 손으로 직접 풀어보니 BFS 라는 확신이 들더군요!_! 숨바꼭질도 시리즈? 가 많던데 한번 풀어보면 좋을것 같습니다.

---
# ⭐ 트리순회
사실 이문제는 제가 잘 못풀었습니다. 제일 어려웠...
그래서 티스토리 참고하면서 이해를했는데
가장 깔끔해보이는 풀이를 써봤습니다.
문제에서 나온그대로 전위순회의 정의를 사용하여 탐색 방법을 재귀로 나열하고, root 가 "." 이 나오는 순간 재귀함수스택을 지우는 방식으로 구현했습니다.
(순영님의 설명을 기다리겠습니다 ㅎㅎ_ 
